### PR TITLE
Add gpio & i2c groups to domoticz user

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ For example, to add the json command to retrieve the status of a device (/json.h
     }
 ````
 
-All IPv6 and IPv4 address within the local network (192.168.0.0/24) are authorized as API.
-As far as I know, there is no way to use such filter for IPv6 address : You may remove the authorization by removing or commenting this line in `/etc/nginx/conf.d/yourdomain.tld.d/domoticz.conf`:
+All IPv4 addresses within the local network (192.168.0.0/24) and *all IPv6* addresses are authorized as API.
+As far as I know, there is no way to filter for IPv6 address on local network : You may remove the authorization by removing or commenting this line in `/etc/nginx/conf.d/yourdomain.tld.d/domoticz.conf`:
 ````
 allow ::/1;
 ````

--- a/README_fr.md
+++ b/README_fr.md
@@ -66,8 +66,8 @@ Par exemple, pour ajouter la commmande json pour retrouver le statut d'un équip
     }
 ````
 
-Toutes les adresses IPv6 et les adresses IPv4 du réseau local (192.168.0.0/24) sont autorisées pour l'API.
-A ma connaissance, il n'y a pas moyen d'effectuer un tel filtre pour les adresses IPv6, vous pouvez donc retirer leur autorisation en enlevant ou en commentant la ligne suivante dans `/etc/nginx/conf.d/yourdomain.tld.d/domoticz.conf`:
+Toutes les adresses IPv4 du réseau local (192.168.0.0/24) et toutes les adresses IPv6 sont autorisées pour l'API.
+A ma connaissance, il n'y a pas moyen d'effectuer un filtre pour les adresses IPv6 sur le réseau local, vous pouvez donc retirer leur autorisation en enlevant ou en commentant la ligne suivante dans `/etc/nginx/conf.d/yourdomain.tld.d/domoticz.conf`:
 ````
 allow ::/1;
 ````

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -8,7 +8,7 @@ Group=__APP__
 ExecStart=__FINALPATH__/domoticz -www __PORT__ -sslwww 0 -log /var/log/__APP__/__APP__.log -loglevel normal,status
 WorkingDirectory=__FINALPATH__/
 PermissionsStartOnly=true
-ExecStartPre=setcap 'cap_net_bind_service=+ep' __FINALPATH__/domoticz
+ExecStartPre=setcap 'cap_net_bind_service=+ep cap_net_raw=+eip' __FINALPATH__/domoticz
 Restart=on-failure
 RestartSec=1m
 #StandardOutput=null

--- a/issue_template.md
+++ b/issue_template.md
@@ -31,7 +31,7 @@ about: When creating a bug report, please use the following template to provide 
 
 - *If you performed a command from the CLI, the command itself is enough. For example:*
     ```sh
-    sudo yunohost app install REPLACEBYYOURAPP
+    sudo yunohost app install domoticz_ynh
     ```
 - *If you used the webadmin, please perform the equivalent command from the CLI first.*
 - *If the error occurs in your browser, explain what you did:*

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -15,4 +15,4 @@
 ---
 *If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*
 
-[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/)  
+[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/domoticz_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/domoticz_ynh_ynh%20PR-NUM-%20(USERNAME)/)  

--- a/scripts/install
+++ b/scripts/install
@@ -119,8 +119,8 @@ ynh_script_progression --message="Configuring system user..." --weight=1
 
 # Create a system user
 ynh_system_user_create --username=$app
-#allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.)
-usermod -a -G dialout $app
+#allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
+usermod -a -G dialout i2c $app
 
 #allow app user to restart service on startup
 cp ../conf/sudoer ../conf/$app.conf

--- a/scripts/install
+++ b/scripts/install
@@ -120,10 +120,15 @@ ynh_script_progression --message="Configuring system user..." --weight=1
 # Create a system user
 ynh_system_user_create --username=$app
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout $app
-usermod -a -G i2c $app
-usermod -a -G gpio $app
-
+if grep dialout -q < /etc/group; then
+	usermod -a -G dialout $app
+fi
+if grep i2c -q < /etc/group; then
+	usermod -a -G i2c $app
+fi
+if grep gpio -q < /etc/group; then
+	usermod -a -G gpio $app
+fi
 
 #allow app user to restart service on startup
 cp ../conf/sudoer ../conf/$app.conf

--- a/scripts/install
+++ b/scripts/install
@@ -120,7 +120,10 @@ ynh_script_progression --message="Configuring system user..." --weight=1
 # Create a system user
 ynh_system_user_create --username=$app
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout i2c gpio $app
+usermod -a -G dialout $app
+usermod -a -G i2c $app
+usermod -a -G gpio $app
+
 
 #allow app user to restart service on startup
 cp ../conf/sudoer ../conf/$app.conf

--- a/scripts/install
+++ b/scripts/install
@@ -120,7 +120,7 @@ ynh_script_progression --message="Configuring system user..." --weight=1
 # Create a system user
 ynh_system_user_create --username=$app
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout i2c $app
+usermod -a -G dialout i2c gpio $app
 
 #allow app user to restart service on startup
 cp ../conf/sudoer ../conf/$app.conf

--- a/scripts/restore
+++ b/scripts/restore
@@ -92,9 +92,15 @@ ynh_restore_file --origin_path="/etc/sudoers.d/$app"
 #Both folder and database file must be own by app user for domoticz to work and allow internal upgrade
 chown -R $app: $final_path
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout $app
-usermod -a -G i2c $app
-usermod -a -G gpio $app
+if grep dialout -q < /etc/group; then
+	usermod -a -G dialout $app
+fi
+if grep i2c -q < /etc/group; then
+	usermod -a -G i2c $app
+fi
+if grep gpio -q < /etc/group; then
+	usermod -a -G gpio $app
+fi
 
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -76,8 +76,7 @@ ynh_script_progression --message="Recreating the dedicated system user..." --wei
 
 # Create the dedicated user (if not existing)
 ynh_system_user_create --username=$app
-#allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.)
-usermod -a -G dialout $app
+
 
 
 #Restore user authorization to restart server
@@ -92,6 +91,9 @@ ynh_restore_file --origin_path="/etc/sudoers.d/$app"
 #chown -R root: $final_path
 #Both folder and database file must be own by app user for domoticz to work and allow internal upgrade
 chown -R $app: $final_path
+#allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
+usermod -a -G dialout i2c $app
+
 
 #=================================================
 # SPECIFIC RESTORATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -92,7 +92,9 @@ ynh_restore_file --origin_path="/etc/sudoers.d/$app"
 #Both folder and database file must be own by app user for domoticz to work and allow internal upgrade
 chown -R $app: $final_path
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout i2c gpio $app
+usermod -a -G dialout $app
+usermod -a -G i2c $app
+usermod -a -G gpio $app
 
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -92,7 +92,7 @@ ynh_restore_file --origin_path="/etc/sudoers.d/$app"
 #Both folder and database file must be own by app user for domoticz to work and allow internal upgrade
 chown -R $app: $final_path
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout i2c $app
+usermod -a -G dialout i2c gpio $app
 
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -175,7 +175,9 @@ ynh_script_progression --message="Making sure dedicated system user exists..."
 # Create a dedicated user (if not existing)
 ynh_system_user_create --username=$app
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout i2c gpio $app
+usermod -a -G dialout $app
+usermod -a -G i2c $app
+usermod -a -G gpio $app
 
 #allow app user to restart service on startup
 cp ../conf/sudoer ../conf/$app.conf

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -175,7 +175,7 @@ ynh_script_progression --message="Making sure dedicated system user exists..."
 # Create a dedicated user (if not existing)
 ynh_system_user_create --username=$app
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout i2c $app
+usermod -a -G dialout i2c gpio $app
 
 #allow app user to restart service on startup
 cp ../conf/sudoer ../conf/$app.conf

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -174,6 +174,8 @@ ynh_script_progression --message="Making sure dedicated system user exists..."
 
 # Create a dedicated user (if not existing)
 ynh_system_user_create --username=$app
+#allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
+usermod -a -G dialout i2c $app
 
 #allow app user to restart service on startup
 cp ../conf/sudoer ../conf/$app.conf

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -175,9 +175,15 @@ ynh_script_progression --message="Making sure dedicated system user exists..."
 # Create a dedicated user (if not existing)
 ynh_system_user_create --username=$app
 #allow user to access USB / serial port to communicate with tools (RFXtrx, Z-wave dongle, etc.) & i2c bus
-usermod -a -G dialout $app
-usermod -a -G i2c $app
-usermod -a -G gpio $app
+if grep dialout -q < /etc/group; then
+	usermod -a -G dialout $app
+fi
+if grep i2c -q < /etc/group; then
+	usermod -a -G i2c $app
+fi
+if grep gpio -q < /etc/group; then
+	usermod -a -G gpio $app
+fi
 
 #allow app user to restart service on startup
 cp ../conf/sudoer ../conf/$app.conf


### PR DESCRIPTION
## Problem
- no access to gpio and i2c

## Solution
- add domoticz user to group

## PR Status
- [X] Code finished.
- [x] Tested with Package_check.
- [X] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/)  
