### PR TITLE
Remove test process w/o Mosquitto

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Very light weight open sources home automation system that lets you monitor and configure miscellaneous devices
 
 **Shipped version:** 2020.2~ynh4
-
 ## Disclaimers / important information
 
 Domoticz is a Home Automation system design to control various devices and receive input from various sensors.

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,8 +17,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Logiciel open sources et gratuit de domotique qui vous permet de configurer un grand nombre d'appareils
 
-**Version incluse :** 2020.2~ynh4
-
+**Version incluse :** 2020.2~ynh4
 ## Avertissements / informations importantes
 
 Domoticz est un système de domotique permettant de controler différents objets et de recevoir des données de divers senseurs

--- a/check_process
+++ b/check_process
@@ -28,27 +28,27 @@ Notification=none
 	; commit=048ae59a016755b0829a4e8f3ed5d0dbbd1b826b
 		name=Package ynh3
 
-;; Test sans Mosquitto
-	; Manifest
-		domain="domain.tld" (DOMAIN)
-		path="/domoticz" (PATH)
-		is_public=1 (PUBLIC|public=1|private=0)
-		mqtt_domain="sub.domain.tld"
-	; Checks
-		pkg_linter=0
-		setup_sub_dir=1
-		setup_root=1
-		setup_private=1
-		setup_public=1
-		upgrade=1
-		upgrade=1	from_commit=048ae59a016755b0829a4e8f3ed5d0dbbd1b826b
-		backup_restore=1
-		port_already_use=1
-		change_url=1
-;;; Options
-Email=nicolas@aubonalbanais.ovh
-Notification=none
-;;; Upgrade options
-	; commit=048ae59a016755b0829a4e8f3ed5d0dbbd1b826b
-		name=Package ynh3
+##;; Test sans Mosquitto
+##	; Manifest
+##		domain="domain.tld" (DOMAIN)
+##		path="/domoticz" (PATH)
+##		is_public=1 (PUBLIC|public=1|private=0)
+##		mqtt_domain="sub.domain.tld"
+##	; Checks
+##		pkg_linter=0
+##		setup_sub_dir=1
+##		setup_root=1
+##		setup_private=1
+##		setup_public=1
+##		upgrade=1
+##		upgrade=1	from_commit=048ae59a016755b0829a4e8f3ed5d0dbbd1b826b
+##		backup_restore=1
+##		port_already_use=1
+##		change_url=1
+##;;; Options
+##Email=nicolas@aubonalbanais.ovh
+##Notification=none
+##;;; Upgrade options
+##	; commit=048ae59a016755b0829a4e8f3ed5d0dbbd1b826b
+##		name=Package ynh3
 


### PR DESCRIPTION
Test process systematically failed for test process w/o Mosquitto (due to some issue on the domains settings).
this artificially decrease the package notation.
test process w/o Mosquitto has been commented.