### PR TITLE
Allow systemd service to connect to bluetooth addresses. Fixes #16.

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -21,7 +21,7 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 #Private device restrict access to device in /dev/, so to any devices like razberry, zigate, etc.
 #PrivateDevices=yes
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_BLUETOOTH
 RestrictNamespaces=yes
 RestrictRealtime=yes
 #Same : restrict access to devices


### PR DESCRIPTION
## Problem

- Domoticz could not connect to bluetooth devices, due to too strict systemd configuration

## Solution

- Allowed `AF_BLUETOOTH` for `RestrictAddressFamilies` in `systemd.service`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
