### PR TITLE
Change authheader

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ allow ::/1;
 This will authorized only IPv4 within local network to access your domoticz API.
 You may add individual IPv6 address in the same way.
 
-**Shipped version:** 2020.2~ynh7
+**Shipped version:** 2020.2~ynh8
 ## Disclaimers / important information
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -127,7 +127,7 @@ Ceci autorisera seulement les adresses IPv4 local a accéder aux API de domoticz
 Vous pouvez ajouter des adresses IPv6 de la même façon.
 
 
-**Version incluse :** 2020.2~ynh7
+**Version incluse :** 2020.2~ynh8
 ## Avertissements / informations importantes
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Home automation system that lets you monitor and configure miscellaneous devices",
         "fr": "Logiciel de domotique qui vous permet de configurer un grand nombre d'appareils"
     },
-    "version": "2020.2~ynh7",
+    "version": "2020.2~ynh8",
     "url": "https://www.domoticz.com",
     "upstream": {
         "license": "GPL-3.0-or-later",

--- a/scripts/install
+++ b/scripts/install
@@ -257,7 +257,11 @@ then
 	# Everyone can access the app.
 	# The "main" permission is automatically created before the install script.
 	ynh_permission_update --permission="main" --add="visitors"
+
 fi
+
+#remove the authentication header preventing login from 2023.2 and 11.2.3 onward
+ynh_permission_url --permission="main" --auth_header=false
 
 #API & MQTT should stay publicly accessible.  
 ynh_permission_create --permission="domoticz_API" --label="api" --url="$domain$api_path" --allowed="visitors" --show_tile="false" --protected="true"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -152,6 +152,9 @@ if [ -d "/var/log/$app/$app" ]; then
 	ynh_secure_remove "/var/log/$app/$app"
 fi
 
+#remove the authentication header preventing login from 2023.2 and 11.2.3 onward
+ynh_permission_url --permission="main" --auth_header=false
+
 #=================================================
 # CREATE DEDICATED USER
 #=================================================


### PR DESCRIPTION
## Problem

- Since 11.2.3 and 2023.1, the authorization header sent by yunohost prevent login in domoticz: see #19 

## Solution

- Set auth_header to false in install and upgrade script