### PR TITLE
Set correct key for Debian extra repo

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -7,5 +7,6 @@
 - [Le o README en galego](README_gl.md)
 - [Baca README dalam bahasa bahasa Indonesia](README_id.md)
 - [Lees de README in het Nederlands](README_nl.md)
+- [Przeczytaj README w języku polski](README_pl.md)
 - [Прочитать README на русский](README_ru.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ It shall NOT be edited by hand.
 
 # Domoticz for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![Working status](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![Integration level](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Working status](https://apps.yunohost.org/badge/state/domoticz)
+![Maintenance status](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![Install Domoticz with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,9 @@ No se debe editar a mano.
 
 # Domoticz para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Estado funcional](https://apps.yunohost.org/badge/state/domoticz)
+![Estado En Mantención](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![Instalar Domoticz con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,9 @@ EZ editatu eskuz.
 
 # Domoticz YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![Integrazio maila](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Funtzionamendu egoera](https://apps.yunohost.org/badge/state/domoticz)
+![Mantentze egoera](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![Instalatu Domoticz YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,9 @@ Il NE doit PAS être modifié à la main.
 
 # Domoticz pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![Niveau d’intégration](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Statut du fonctionnement](https://apps.yunohost.org/badge/state/domoticz)
+![Statut de maintenance](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![Installer Domoticz avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,9 @@ NON debe editarse manualmente.
 
 # Domoticz para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Estado de funcionamento](https://apps.yunohost.org/badge/state/domoticz)
+![Estado de mantemento](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![Instalar Domoticz con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/README_id.md
+++ b/README_id.md
@@ -5,7 +5,9 @@ Ini TIDAK boleh diedit dengan tangan.
 
 # Domoticz untuk YunoHost
 
-[![Tingkat integrasi](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![Status kerja](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![Status pemeliharaan](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![Tingkat integrasi](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Status kerja](https://apps.yunohost.org/badge/state/domoticz)
+![Status pemeliharaan](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![Pasang Domoticz dengan YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -5,7 +5,9 @@ Hij mag NIET handmatig aangepast worden.
 
 # Domoticz voor Yunohost
 
-[![Integratieniveau](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![Mate van functioneren](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![Onderhoudsstatus](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![Integratieniveau](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Mate van functioneren](https://apps.yunohost.org/badge/state/domoticz)
+![Onderhoudsstatus](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![Domoticz met Yunohost installeren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -1,0 +1,66 @@
+<!--
+To README zostało automatycznie wygenerowane przez <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Nie powinno być ono edytowane ręcznie.
+-->
+
+# Domoticz dla YunoHost
+
+[![Poziom integracji](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Status działania](https://apps.yunohost.org/badge/state/domoticz)
+![Status utrzymania](https://apps.yunohost.org/badge/maintained/domoticz)
+
+[![Zainstaluj Domoticz z YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
+
+*[Przeczytaj plik README w innym języku.](./ALL_README.md)*
+
+> *Ta aplikacja pozwala na szybką i prostą instalację Domoticz na serwerze YunoHost.*  
+> *Jeżeli nie masz YunoHost zapoznaj się z [poradnikiem](https://yunohost.org/install) instalacji.*
+
+## Przegląd
+
+Domoticz is a Home Automation system design to control various devices and receive input from various sensors.
+For example this system can be used with: 
+
+* Light switches
+* Door sensors
+* Doorbells
+* Security devices
+* Weather sensors like: UV/Rain/Wind Meters
+* Temperature Sensors
+* Pulse Meters
+* Voltage / AD Meters
+* And more...
+
+
+The MQTT broker Mosquitto is integrated into the package and requires its own domain or subdomain. It's an optional setting.
+You may also install the [Mosquitto package](https://github.com/YunoHost-Apps/mosquitto_ynh) without using the one provided by domoticz_ynh.
+
+**Dostarczona wersja:** 2024.6~ynh2
+
+## Zrzuty ekranu
+
+![Zrzut ekranu z Domoticz](./doc/screenshots/domoticz_Switches_screen.png)
+![Zrzut ekranu z Domoticz](./doc/screenshots/domoticz_floorplan_machineon.png)
+
+## Dokumentacja i zasoby
+
+- Oficjalna strona aplikacji: <https://domoticz.com/>
+- Oficjalna dokumentacja: <https://www.domoticz.com/DomoticzManual.pdf>
+- Oficjalna dokumentacja dla administratora: <https://www.domoticz.com/wiki/Main_Page>
+- Repozytorium z kodem źródłowym: <https://github.com/domoticz/domoticz>
+- Sklep YunoHost: <https://apps.yunohost.org/app/domoticz>
+- Zgłaszanie błędów: <https://github.com/YunoHost-Apps/domoticz_ynh/issues>
+
+## Informacje od twórców
+
+Wyślij swój pull request do [gałęzi `testing`](https://github.com/YunoHost-Apps/domoticz_ynh/tree/testing).
+
+Aby wypróbować gałąź `testing` postępuj zgodnie z instrukcjami:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/domoticz_ynh/tree/testing --debug
+lub
+sudo yunohost app upgrade domoticz -u https://github.com/YunoHost-Apps/domoticz_ynh/tree/testing --debug
+```
+
+**Więcej informacji o tworzeniu paczek aplikacji:** <https://yunohost.org/packaging_apps>

--- a/README_ru.md
+++ b/README_ru.md
@@ -5,7 +5,9 @@
 
 # Domoticz для YunoHost
 
-[![Уровень интеграции](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![Состояние работы](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![Состояние сопровождения](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![Уровень интеграции](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![Состояние работы](https://apps.yunohost.org/badge/state/domoticz)
+![Состояние сопровождения](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![Установите Domoticz с YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,9 @@
 
 # YunoHost 上的 Domoticz
 
-[![集成程度](https://dash.yunohost.org/integration/domoticz.svg)](https://ci-apps.yunohost.org/ci/apps/domoticz/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/domoticz.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/domoticz.maintain.svg)
+[![集成程度](https://apps.yunohost.org/badge/integration/domoticz)](https://ci-apps.yunohost.org/ci/apps/domoticz/)
+![工作状态](https://apps.yunohost.org/badge/state/domoticz)
+![维护状态](https://apps.yunohost.org/badge/maintained/domoticz)
 
 [![使用 YunoHost 安装 Domoticz](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=domoticz)
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -108,6 +108,6 @@ ram.runtime = "50M"
         # So if we're in a debian 12 and libssl1.1 is not installed, we will install it from bullseye repo
         # As soon as compilation is done with libssl.so.3, this extra repo must be removed
         extras.libssl.repo="deb http://security.debian.org/debian-security bullseye-security main"
-        extras.libssl.key="5C808C2B65558117"
+        extras.libssl.key="https://security.debian.org/debian-security/dists/bullseye-security/Release.gpg"
         extras.libssl.packages=["libssl1.1"]
         ##############################

--- a/manifest.toml
+++ b/manifest.toml
@@ -108,6 +108,6 @@ ram.runtime = "50M"
         # So if we're in a debian 12 and libssl1.1 is not installed, we will install it from bullseye repo
         # As soon as compilation is done with libssl.so.3, this extra repo must be removed
         extras.libssl.repo="deb http://security.debian.org/debian-security bullseye-security main"
-        extras.libssl.key="https://security.debian.org/debian-security/dists/bullseye-security/InRelease"
+        extras.libssl.key="112695A0E562B32A"
         extras.libssl.packages=["libssl1.1"]
         ##############################

--- a/manifest.toml
+++ b/manifest.toml
@@ -108,6 +108,6 @@ ram.runtime = "50M"
         # So if we're in a debian 12 and libssl1.1 is not installed, we will install it from bullseye repo
         # As soon as compilation is done with libssl.so.3, this extra repo must be removed
         extras.libssl.repo="deb http://security.debian.org/debian-security bullseye-security main"
-        extras.libssl.key="https://security.debian.org/debian-security/dists/bullseye-security/Release.gpg"
+        extras.libssl.key="https://security.debian.org/debian-security/dists/bullseye-security/InRelease"
         extras.libssl.packages=["libssl1.1"]
         ##############################

--- a/manifest.toml
+++ b/manifest.toml
@@ -95,7 +95,7 @@ ram.runtime = "50M"
         mqtt_websocket.default = 8883
 
         [resources.apt]
-        packages = "libudev-dev, python3-dev, libcurl4, libusb-0.1-4"
+        packages = "libudev-dev, python3-dev, libcurl4, libusb-0.1-4 debian-archive-keyring"
         packages_from_raw_bash = """
         if [ "$mqtt_domain" != "$domain" ]; then
             echo mosquitto mosquitto-clients;

--- a/manifest.toml
+++ b/manifest.toml
@@ -95,7 +95,7 @@ ram.runtime = "50M"
         mqtt_websocket.default = 8883
 
         [resources.apt]
-        packages = "libudev-dev, python3-dev, libcurl4, libusb-0.1-4 debian-archive-keyring"
+        packages = "libudev-dev, python3-dev, libcurl4, libusb-0.1-4"
         packages_from_raw_bash = """
         if [ "$mqtt_domain" != "$domain" ]; then
             echo mosquitto mosquitto-clients;
@@ -108,6 +108,6 @@ ram.runtime = "50M"
         # So if we're in a debian 12 and libssl1.1 is not installed, we will install it from bullseye repo
         # As soon as compilation is done with libssl.so.3, this extra repo must be removed
         extras.libssl.repo="deb http://security.debian.org/debian-security bullseye-security main"
-        extras.libssl.key="112695A0E562B32A"
+        extras.libssl.key="8DD47936"
         extras.libssl.packages=["libssl1.1"]
         ##############################

--- a/manifest.toml
+++ b/manifest.toml
@@ -108,6 +108,6 @@ ram.runtime = "50M"
         # So if we're in a debian 12 and libssl1.1 is not installed, we will install it from bullseye repo
         # As soon as compilation is done with libssl.so.3, this extra repo must be removed
         extras.libssl.repo="deb http://security.debian.org/debian-security bullseye-security main"
-        extras.libssl.key="8DD47936"
+        extras.libssl.key="https://ftp-master.debian.org/keys/archive-key-11-security.asc"
         extras.libssl.packages=["libssl1.1"]
         ##############################


### PR DESCRIPTION
## Problem

- The link to the asc file for the key for debian-security extra repo was wrong. It did not show in the CI test and it may or may not break the upgrade depending on the bullseye->bookworm upgrade path


## Solution

- Set correct asc file link

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
